### PR TITLE
fix(ci): явные permissions в GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,6 +12,9 @@ on:
       - 'backend/**'
       - '.github/workflows/backend.yml'
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.11'
   DJANGO_SETTINGS_MODULE: skill_division.settings

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -12,6 +12,9 @@ on:
       - 'bot/**'
       - '.github/workflows/bot.yml'
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.11'
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,6 +12,9 @@ on:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
 
@@ -85,6 +88,9 @@ jobs:
     name: Сборка продакшн-версии
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -20,6 +20,9 @@ on:
       - 'bot/Dockerfile*'
       - '.github/workflows/infra.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Валидация конфигураций


### PR DESCRIPTION
## Summary
- Добавлен `permissions: contents: read` на уровне workflow (backend, frontend, bot, infra)
- `actions: write` только у frontend build — для `upload-artifact`

Закрывает CodeQL alerts #5–#15 (Workflow does not contain permissions).

## Test plan
- [x] CI проходит на PR
- [x] CodeQL alerts закрываются после merge